### PR TITLE
Changing typo and wrong argument on the train page

### DIFF
--- a/products/global-cli-configs/cli-api/grid-train.md
+++ b/products/global-cli-configs/cli-api/grid-train.md
@@ -50,7 +50,7 @@ Example 2: Run 8 variations of this script, each on 8 GPUs
 
 ```bash
 grid run \
--g_instance_type 8_v100_32gb \
+--instance_type 8_v100_32gb \
 model.py --learning_rate "uniform(1e-5, 1e-1, 4)" --layers "[2, 4]"
 ```
 


### PR DESCRIPTION
This is a WIP PR. I am waiting on @williamFalcon comment on
GI-4455 https://linear.app/gridai/issue/GI-4455/the-documention-is-confusing-for-the-cli-run
to change the picture portion.