### PR TITLE
removed --disk_size param from all run docs except examples

### DIFF
--- a/products/global-cli-configs/cli-api/grid-train.md
+++ b/products/global-cli-configs/cli-api/grid-train.md
@@ -142,7 +142,6 @@ Here's a summary of all the available grid flags \(all are optional\)
 | --datastore\_name | name of datastore to mount | - |
 | --datastore\_version | version of datastore to mount | - |
 | --datastore\_mount\_dir | directory where to mount datastore | /opt/datastore |
-| --disk\_size | size of disk attached to machine | 200 GB |
 | --description | additional context for this run | - |
 | --framework | machine learning framework | - |
 | --gpus | the number of GPUs per experiment | 0 |
@@ -232,14 +231,6 @@ Optional description for a run
 
 ```text
 grid run --description "Trying Adam optimizer" my_script.py
-```
-
-### `--disk_size`
-
-Disk size to be attached to every experiment node. Number indicates Gb.
-
-```text
-grid run --disk_size 300 --my_script.py
 ```
 
 ### **`--gpus`**

--- a/products/run-run-and-sweep-github-files/yaml-configs/README.md
+++ b/products/run-run-and-sweep-github-files/yaml-configs/README.md
@@ -53,7 +53,6 @@ compute:
   train:
 
     cpus: 1                       # Number of CPUs
-    disk_size: 200                # Disk size
     gpus: 0                       # Number of GPUs
     instance: t2.xlarge           # AWS instance type
     memory: null                  # RAM memory

--- a/products/run-run-and-sweep-github-files/yaml-configs/yaml-api.md
+++ b/products/run-run-and-sweep-github-files/yaml-configs/yaml-api.md
@@ -25,7 +25,6 @@ compute:
   train:
 
     cpus: 1                       # Number of CPUs
-    disk_size: 200                # Disk size
     gpus: 0                       # Number of GPUs
     instance: t2.xlarge           # AWS instance type
     memory: null                  # RAM memory
@@ -82,7 +81,6 @@ compute:
 
   train:
     cpus: 1
-    disk_size: 200
     gpus: 0
     instance: t2.xlarge
     memory: null


### PR DESCRIPTION
Hey @hhsecond I removed the `--disk_size` param from all run docs, but not the current examples with badges as I don't want to break anything there. Can you take a look?