### PR TITLE
Fix typo: datastores -> datastore

### DIFF
--- a/products/add-data-to-grid-datastores/periodic-upload.md
+++ b/products/add-data-to-grid-datastores/periodic-upload.md
@@ -11,7 +11,7 @@ Here's an example that uploads a new version of a datastore every hour:
 crontab -l > mycron
 
 #run datastore upload every hour every day
-echo "0 * * * * grid datastores create --source data/path --name dataset" >> mycron    
+echo "0 * * * * grid datastore create --source data/path --name dataset" >> mycron    
 
 #install new cron file
 crontab mycron


### PR DESCRIPTION
I believe this should be grid datastore instead of datastores, since, at least on my session, `grid datastores` is not a valid command.