### PR TITLE
Fix incorrect use of curl remote name option

### DIFF
--- a/start-here/typical-workflow-cli-user.md
+++ b/start-here/typical-workflow-cli-user.md
@@ -96,7 +96,7 @@ In a **real** workflow, you would already have the data locally or on a cluster.
 
 ```yaml
 # download
-curl https://pl-flash-data.s3.amazonaws.com/cifar5.zip -O cifar5.zip
+curl https://pl-flash-data.s3.amazonaws.com/cifar5.zip -o cifar5.zip
 
 # unzip
 unzip cifar5.zip


### PR DESCRIPTION
- Change the `-O` (remote name) option to `-o` (output); an alternative fix is moving the `-O` option before the URL and removing the target file name