### PR TITLE
Removing datastore list command in favour keeping the APIs consistent

### DIFF
--- a/products/global-cli-configs/cli-api/grid-datastores.md
+++ b/products/global-cli-configs/cli-api/grid-datastores.md
@@ -19,6 +19,12 @@ grid run --datastore_name my_datastore_name \
            --my_data /opt/datastore
 ```
 
+List all the available datastores with:
+
+```bash
+grid datastore
+```
+
 ## create
 
 Creates a datastore. Datastores are directories that are compressed into and mounted into your experiment environment.

--- a/products/global-cli-configs/cli-api/grid-datastores.md
+++ b/products/global-cli-configs/cli-api/grid-datastores.md
@@ -66,13 +66,6 @@ Name of datastore to delete. You will also need to supply a `--version`.
 
 Version of the datastore to delete. You will also need to supply a `--name`.
 
-## list
-
-Lists all available datastores.
-
-```bash
-grid datastore list
-```
 
 ## resume
 


### PR DESCRIPTION
For listing other resources, we use `grid <resource>` and we recently removed `grid datastore list` to keep this consistent for datastore as well. For listing datastore, one can do `grid datastore`