### PR TITLE
Fix broken link to grid-cluster-context.md

### DIFF
--- a/products/run-run-and-sweep-github-files/yaml-configs/yaml-api.md
+++ b/products/run-run-and-sweep-github-files/yaml-configs/yaml-api.md
@@ -7,7 +7,7 @@ In addition to CLI parameters, Grid supports the use of YML files so you don't h
 The following YML file contains a commented version of every YML key. You need to provide these keys when writing a config file and change the properties to what you need.
 
 {% hint style="danger" %}
-Use either [cluster context](../global-cli-configs/cli-api/grid-cluster-context.md) or make sure to place your cluster ID in the `cluster` field, replacing the **XXXXXX** placeholder.
+Use either [cluster context](../../global-cli-configs/cli-api/grid-cluster-context.md) or make sure to place your cluster ID in the `cluster` field, replacing the **XXXXXX** placeholder.
 {% endhint %}
 
 ```text


### PR DESCRIPTION
The link needed an additional '../' since the global-cli-configs folder was in the products directory, not in the run-run-and-sweep-github-files directory.