### PR TITLE
Doc 170 update documentation syntax

### DIFF
--- a/docs/products/add-data-to-grid-datastores/README.md
+++ b/docs/products/add-data-to-grid-datastores/README.md
@@ -55,5 +55,5 @@ Cons:
 Once you have created a datastore, simply pass in its name to your script and Grid will auto-resolve the path. Assume you have a datastore named _cats_ and you want to use version 1:
 
 ```bash
-grid run main.py --data_dir grid:cats:1
+grid run main.py --datastore_mount_dir /datastore/cats/1
 ```

--- a/docs/products/add-data-to-grid-datastores/README.md
+++ b/docs/products/add-data-to-grid-datastores/README.md
@@ -55,5 +55,5 @@ Cons:
 Once you have created a datastore, simply pass in its name to your script and Grid will auto-resolve the path. Assume you have a datastore named _cats_ and you want to use version 1:
 
 ```bash
-grid run main.py --datastore_mount_dir /datastore/cats/1
+grid run main.py --data_dir /datastore/cats/1
 ```

--- a/docs/products/global-cli-configs/cli-api/grid-datastores.md
+++ b/docs/products/global-cli-configs/cli-api/grid-datastores.md
@@ -71,7 +71,7 @@ Version of the datastore to delete. You will also need to supply a `--name`.
 Lists all available datastores.
 
 ```bash
-grid datastore list
+grid datastore
 ```
 
 ## resume

--- a/docs/products/runs/attaching-datastores.md
+++ b/docs/products/runs/attaching-datastores.md
@@ -7,7 +7,7 @@
 You can mount a datastore to a run to make your experiments run faster! By default, the datastore is mounted at /datastore. When attaching datastores to a run, take note of the path your script uses. For example if your script takes an argument _my_data_path_ and you want to mount the _cats_ datastore:
 
 ```bash
-grid run main.py --my_data_path grid:cats:1
+grid run main.py --my_data_path /datastore/cats/1
 ```
 
 ## Datastore paths
@@ -68,17 +68,17 @@ which is equivalent to calling your script like so:
 python pl_mnist.py --root /datastore
 
 # with grid
-python pl_mnist.py --root grid:my-dataset:1
+python pl_mnist.py --root /datastore/my-dataset/1
 ```
 
 The datastore path has 3 parts:
 
 ```bash
-grid:[name]:[version]
+/datastore:[name]:[version]
 ```
 
 Example, datastore named elephant (version 3)
 
 ```bash
-grid:elephant:3
+/datastore/elephant/3
 ```

--- a/docs/products/runs/attaching-datastores.md
+++ b/docs/products/runs/attaching-datastores.md
@@ -74,7 +74,7 @@ python pl_mnist.py --root /datastore/my-dataset/1
 The datastore path has 3 parts:
 
 ```bash
-/datastore:[name]:[version]
+/datastore/[name]/[version]
 ```
 
 Example, datastore named elephant (version 3)

--- a/docs/products/sessions/README.md
+++ b/docs/products/sessions/README.md
@@ -46,6 +46,6 @@ grid session create --instance_type 2_m60_8gb
 The equivalent CLI command:
 
 ```text
-grid session delete $INTERACTIVE_NODE_ID
+grid session delete $SESSION_NAME
 ```
 

--- a/docs/start-here/typical-workflow-cli-user.md
+++ b/docs/start-here/typical-workflow-cli-user.md
@@ -132,7 +132,7 @@ grid datastore create --source cifar5/ --name cifar5
 make sure it was created
 
 ```bash
-grid datastore list
+grid datastore
 ```
 
 ![Once it's succeeded, it's ready to be used](/images/examples/cli-datastore-list.png)


### PR DESCRIPTION
# What does this PR do? 
Updates some of the doc syntax. Prior to this PR we have old datastore syntax lying around 

1. grid datastore list
2. mount path syntax grid:<datastore name>:<version number>

This PR makes the following changes to relevant points in the documentation

1. grid datastore list -> grid datastore
2. grid:<datastore name>:<version number> -> /datastore/<datastore name>/<version number>

This is important so the documentation stays consistent with the current release.
