### PR TITLE
Doc 182 share data between sessions

### DIFF
--- a/docs/products/sessions/README.md
+++ b/docs/products/sessions/README.md
@@ -59,5 +59,5 @@ grid session mount <your session> <created session mount dir>
 mkdir <created session mount dir>/shared_data
 
 # to share data from a session to another session
-cp -R <dir of interest in created session mount dir> ./shared_data
+cp -R <dir of interest in created session mount dir> <other session mount dir>/shared_data
 ```

--- a/docs/products/sessions/README.md
+++ b/docs/products/sessions/README.md
@@ -59,5 +59,5 @@ grid session mount <your session> <created session mount dir>
 mkdir <created session mount dir>/shared_data
 
 # to share data from a session to another session
-cp -R <dir of interest in created session mount dir> <other session mount dir>/shared_data
+cp -R <source> <destination>/shared_data
 ```

--- a/docs/products/sessions/README.md
+++ b/docs/products/sessions/README.md
@@ -54,9 +54,9 @@ At this time the only supported way to share data between sessions is to mount t
 
 ```
 # Do for each session you wish to share data between
-mkdir <dir for each session mount>
-grid session mount <your session> <created session mount dir>
-mkdir <created session mount dir>/shared_data
+mkdir <dir for SessionA>
+grid session mount <SessionA> <dir for SessionA>
+mkdir <dir for SessionA>/shared_data
 
 # to share data from a session to another session
 cp -R <source> <destination>/shared_data

--- a/docs/products/sessions/README.md
+++ b/docs/products/sessions/README.md
@@ -49,3 +49,15 @@ The equivalent CLI command:
 grid session delete $INTERACTIVE_NODE_ID
 ```
 
+## Share Data Between Sessions
+At this time the only supported way to share data between sessions is to mount the sessions locally and copy files to the local mounts. Establishing SSH connection to your sessions is a prerequisite to this. See these [steps](https://github.com/gridai/grid-docs/blob/doc-182-share-data-between-sessions/docs/products/sessions/how-to-ssh-into-a-session.md) to set up SSH connection with your sessions. After that you can do the following to create your session mounts:
+
+```
+# Do for each session you wish to share data between
+mkdir <dir for each session mount>
+grid session mount <your session> <created session mount dir>
+mkdir <created session mount dir>/shared_data
+
+# to share data from a session to another session
+cp -R <dir of interest in created session mount dir> ./shared_data
+```

--- a/docs/products/sessions/README.md
+++ b/docs/products/sessions/README.md
@@ -50,7 +50,7 @@ grid session delete $INTERACTIVE_NODE_ID
 ```
 
 ## Share Data Between Sessions
-At this time the only supported way to share data between sessions is to mount the sessions locally and copy files to the local mounts. Establishing SSH connection to your sessions is a prerequisite to this. See these [steps](https://github.com/gridai/grid-docs/blob/doc-182-share-data-between-sessions/docs/products/sessions/how-to-ssh-into-a-session.md) to set up SSH connection with your sessions. **Be sure to logout of the interactive session before attempting the next step**. After that you can do the following to create your session mounts:
+At this time the only supported way to share data between sessions is to mount the sessions locally and copy files to the local mounts. Establishing SSH connection to your sessions is a prerequisite to this. See these [steps](./how-to-ssh-into-a-session.md) to set up SSH connection with your sessions. **Be sure to logout of the interactive session before attempting the next step**. After that you can do the following to create your session mounts:
 
 ```
 # Do for each session you wish to share data between

--- a/docs/products/sessions/README.md
+++ b/docs/products/sessions/README.md
@@ -50,7 +50,7 @@ grid session delete $INTERACTIVE_NODE_ID
 ```
 
 ## Share Data Between Sessions
-At this time the only supported way to share data between sessions is to mount the sessions locally and copy files to the local mounts. Establishing SSH connection to your sessions is a prerequisite to this. See these [steps](https://github.com/gridai/grid-docs/blob/doc-182-share-data-between-sessions/docs/products/sessions/how-to-ssh-into-a-session.md) to set up SSH connection with your sessions. After that you can do the following to create your session mounts:
+At this time the only supported way to share data between sessions is to mount the sessions locally and copy files to the local mounts. Establishing SSH connection to your sessions is a prerequisite to this. See these [steps](https://github.com/gridai/grid-docs/blob/doc-182-share-data-between-sessions/docs/products/sessions/how-to-ssh-into-a-session.md) to set up SSH connection with your sessions. **Be sure to logout of the interactive session before attempting the next step**. After that you can do the following to create your session mounts:
 
 ```
 # Do for each session you wish to share data between


### PR DESCRIPTION
# What does this PR do? 
Currently, there is a lack of documentation enabling users to share data between sessions. This PR addresses that by adding instructions for doing this to the datastores section of the documentation. 