### PR TITLE
add sshfs dependency

### DIFF
--- a/docs/start-here/getting-started.md
+++ b/docs/start-here/getting-started.md
@@ -13,6 +13,16 @@ sidebar_position: 1
 The following steps will install the Grid cli tool. Grid commands can then be invoked by calling `grid <grid command> <grid command parameters>`.
 
 1. `pip install lightning-grid --upgrade`
+2. sshfs
+
+### Install sshfs Linux (Debian/Ubuntu)
+```
+sudo apt-get install sshfs
+```
+
+### Install sshfs MacOs
+This is dependent on MacFuse and will yield an error with a vanilla brew install. See [here](https://github.com/telepresenceio/telepresence/issues/1654#issuecomment-873538291) for resolution. 
+
 
 ## Login steps
 


### PR DESCRIPTION
# What does this PR do? 

Currently, we are missing documentation regarding an important OS level dependency for the grid session mount command. Grid session mount in its current state is a wrapper over sshfs. This PR addresses that by adding instructions for installing SSHFS on the getting started page. The idea is the getting started page is the entry point for new Grid users so placing this there will enable them to use grid session mount without issues.

