### PR TITLE
add localdir usecase

### DIFF
--- a/docs/products/runs/localdir.md
+++ b/docs/products/runs/localdir.md
@@ -1,0 +1,6 @@
+## Grid Run localdir Option
+Currently, Grid has a native Github integration to allow running code from public or private repositories. There is currently no support for integration with other code repository providers like BitBucket, Gitlab, etc. We provide the --localdir feature within Grid run to allow users to run scripts from an arbitrary local directory, regardless of where that code is hosted. The main benefit of this feature is for users that do not need to grant Grid access to their code repository accounts. Below is an example usage of the grid run --local dir option.
+
+```
+grid run --localdir run.py
+```

--- a/docs/products/runs/private-repos.md
+++ b/docs/products/runs/private-repos.md
@@ -1,6 +1,17 @@
 # Private Repos
 
-## Access Private Github Repos
+Grid Runs offers to solutions for using private repos:
+1. Utilize the grid run --localdir option
+2. Grant Grid access to your private GitHub repos
+
+## Grid Run localdir Option
+Grid has a good Github integration to allow running code from public or private repositories. This feature enables users to run scripts from an arbitrary local directory, even if the code is not hosted on Github. The main benefit of this feature is for users that do not need to grant Grid access to their GitHub accounts. Below is an example usage of the grid run --local dir option.
+
+```
+grid run --localdir run.py
+```
+
+## Access Private GitHub Repos
 
 By default you can only access public Github repositories on Grid. To grant read access to your private code navigate to Settings &gt; Integrations &gt; Grant access.
 

--- a/docs/products/runs/private-repos.md
+++ b/docs/products/runs/private-repos.md
@@ -5,7 +5,7 @@ Grid Runs offers to solutions for using private repos:
 2. Grant Grid access to your private GitHub repos
 
 ## Grid Run localdir Option
-Currently, Grid has a good Github integration to allow running code from public or private repositories. We do not currently have integration support with other code repo providers like BitBucket, Gitlab, etc. We provide the --localdir feature within Grid run to allow users to run scripts from an arbitrary local directory, regardless of where that code is hosted. The main benefit of this feature is for users that do not need to grant Grid access to their code repository accounts. Below is an example usage of the grid run --local dir option.
+Currently, Grid has a native Github integration to allow running code from public or private repositories. There is currently no support for integration with other code repository providers like BitBucket, Gitlab, etc. We provide the --localdir feature within Grid run to allow users to run scripts from an arbitrary local directory, regardless of where that code is hosted. The main benefit of this feature is for users that do not need to grant Grid access to their code repository accounts. Below is an example usage of the grid run --local dir option.
 
 ```
 grid run --localdir run.py

--- a/docs/products/runs/private-repos.md
+++ b/docs/products/runs/private-repos.md
@@ -5,7 +5,7 @@ Grid Runs offers to solutions for using private repos:
 2. Grant Grid access to your private GitHub repos
 
 ## Grid Run localdir Option
-Grid has a good Github integration to allow running code from public or private repositories. This feature enables users to run scripts from an arbitrary local directory, even if the code is not hosted on Github. The main benefit of this feature is for users that do not need to grant Grid access to their GitHub accounts. Below is an example usage of the grid run --local dir option.
+Currently, Grid has a good Github integration to allow running code from public or private repositories. We do not currently have integration support with other code repo providers like BitBucket, Gitlab, etc. We provide the --localdir feature within Grid run to allow users to run scripts from an arbitrary local directory, regardless of where that code is hosted. The main benefit of this feature is for users that do not need to grant Grid access to their code repository accounts. Below is an example usage of the grid run --local dir option.
 
 ```
 grid run --localdir run.py


### PR DESCRIPTION
# What does this PR do?

This PR addresses community feedback of the lack of --localdir documentation. In order to address this the PR adds the localdir option as a usecase to the existing private repos page under Grid run.
