### PR TITLE
Add lightning fault tolerance

### DIFF
--- a/docs/products/runs/auto-resume-experiments.md
+++ b/docs/products/runs/auto-resume-experiments.md
@@ -50,6 +50,7 @@ Use `--auto_resume` flag to indicate this experiment is safe to resume.
 grid run --use_spot --auto_resume --instance_type p3.2xlarge mnist.py
 ```
 
+
 ### PyTorch Lightning Fault Tolerance
 
 PyTorch Lightning provides a built-in auto-resume mechanism. This would enable you to run your experiments at the cheapest cost without worrying about your experiments being terminated before they should be.  

--- a/docs/products/runs/auto-resume-experiments.md
+++ b/docs/products/runs/auto-resume-experiments.md
@@ -50,5 +50,10 @@ grid run --use_spot --auto_resume --instance_type p3.2xlarge mnist.py
 
 ![image](https://user-images.githubusercontent.com/13732925/148102089-f540356a-a2e6-4e9d-ac1f-51de26691086.png)
 
-#### Lightning Fault Tolerance
-Alternatively, you can enable autoresume experiments via Lightnings Fault tolerance feature see [here](https://pytorch-lightning.readthedocs.io/en/latest/advanced/fault_tolerant_training.html#:~:text=Fault%2Dtolerant%20Training%20is%20an,a%20hardware%20or%20software%20failure.&text=fit()%20fails%20in%20the,and%20everything%20will%20be%20restored.) for the offcial lightning documentation or [here](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/fault_tolerant/automatic.py) for a tested example using the fault tolerance feature and Grid. At this time there are some caveats with reloading.
+#### PyTorch Lightning Fault Tolerance
+
+PyTorch Lightning provides a built-in auto-resume mechanism. This would enable you to run your experiments at the cheapest cost without worrying about your experiments being terminated before they should be.  
+
+You can learn more about the PyTorch Lightning Fault Tolerance mechanism [here](https://pytorch-lightning.readthedocs.io/en/latest/advanced/fault_tolerant_training.html#:~:text=Fault%2Dtolerant%20Training%20is%20an,a%20hardware%20or%20software%20failure.&text=fit()%20fails%20in%20the,and%20everything%20will%20be%20restored.).
+
+Furthermore, PyTorch Lightning provides a reproducible script that you can find [here](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/fault_tolerant/automatic.py) which is tested end-to-end on Grid with the Auto-Resume feature and can be used as a reference for you to get started.

--- a/docs/products/runs/auto-resume-experiments.md
+++ b/docs/products/runs/auto-resume-experiments.md
@@ -49,3 +49,6 @@ grid run --use_spot --auto_resume --instance_type p3.2xlarge mnist.py
 #### UI
 
 ![image](https://user-images.githubusercontent.com/13732925/148102089-f540356a-a2e6-4e9d-ac1f-51de26691086.png)
+
+#### Lightning Fault Tolerance
+Alternatively, you can enable autoresume experiments via Lightnings Fault tolerance feature see [here](https://pytorch-lightning.readthedocs.io/en/latest/advanced/fault_tolerant_training.html#:~:text=Fault%2Dtolerant%20Training%20is%20an,a%20hardware%20or%20software%20failure.&text=fit()%20fails%20in%20the,and%20everything%20will%20be%20restored.) for the offcial lightning documentation or [here](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/fault_tolerant/automatic.py) for a tested example using the fault tolerance feature and Grid. At this time there are some caveats with reloading.

--- a/docs/products/runs/auto-resume-experiments.md
+++ b/docs/products/runs/auto-resume-experiments.md
@@ -38,6 +38,10 @@ In order for experiments to resume from last checkpoint, the following prerequis
 - The process needs to save checkpoint and exit with status code 0
 - On resuming we'll restore all artifacts and code is responsible for resuming from last checkpoint in the file system
 
+#### UI
+
+![image](https://user-images.githubusercontent.com/13732925/148102089-f540356a-a2e6-4e9d-ac1f-51de26691086.png)
+
 #### CLI
 
 Use `--auto_resume` flag to indicate this experiment is safe to resume.
@@ -45,10 +49,6 @@ Use `--auto_resume` flag to indicate this experiment is safe to resume.
 ```bash
 grid run --use_spot --auto_resume --instance_type p3.2xlarge mnist.py
 ```
-
-#### UI
-
-![image](https://user-images.githubusercontent.com/13732925/148102089-f540356a-a2e6-4e9d-ac1f-51de26691086.png)
 
 ### PyTorch Lightning Fault Tolerance
 

--- a/docs/products/runs/auto-resume-experiments.md
+++ b/docs/products/runs/auto-resume-experiments.md
@@ -50,7 +50,7 @@ grid run --use_spot --auto_resume --instance_type p3.2xlarge mnist.py
 
 ![image](https://user-images.githubusercontent.com/13732925/148102089-f540356a-a2e6-4e9d-ac1f-51de26691086.png)
 
-#### PyTorch Lightning Fault Tolerance
+### PyTorch Lightning Fault Tolerance
 
 PyTorch Lightning provides a built-in auto-resume mechanism. This would enable you to run your experiments at the cheapest cost without worrying about your experiments being terminated before they should be.  
 


### PR DESCRIPTION
# What does this PR do? 

This PR adds additional content for how to enable auto resume by relying on lightning's fault tolerance feature. This will further enable users to properly use the auto resume feature.
