### PR TITLE
Doc 208 add clarity to our machine types page

### DIFF
--- a/docs/products/runs/machines.md
+++ b/docs/products/runs/machines.md
@@ -1,6 +1,6 @@
 # Machines
 
-These are the options of available machines. The syntax for this is numberOfAccelerators_acceleratorType_availableMemory. Below is an example utilizing this syntax to a machine with 8 v100 gpus ans 32 GB memory.
+These are the options of available machines. The syntax for this is numberOfAccelerators_acceleratorType_availableMemory. Below is an example utilizing this syntax to create a run on a machine with 8 v100 gpus and 32 GB memory.
 
 ```bash
 grid run --instance_type 8_v100_32gb hello.py --gpus 8

--- a/docs/products/runs/machines.md
+++ b/docs/products/runs/machines.md
@@ -1,6 +1,6 @@
 # Machines
 
-These are the options of available machines
+These are the options of available machines. The syntax for this is numberOfAccelerators_acceleratorType_availableMemory.
 
 ```bash
 grid run --instance_type 8_v100_32gb hello.py --gpus 8

--- a/docs/products/runs/machines.md
+++ b/docs/products/runs/machines.md
@@ -1,6 +1,6 @@
 # Machines
 
-These are the options of available machines. The syntax for this is numberOfAccelerators_acceleratorType_availableMemory.
+These are the options of available machines. The syntax for this is numberOfAccelerators_acceleratorType_availableMemory. Below is an example utilizing this syntax to a machine with 8 v100 gpus ans 32 GB memory.
 
 ```bash
 grid run --instance_type 8_v100_32gb hello.py --gpus 8

--- a/docs/products/sessions/machines.md
+++ b/docs/products/sessions/machines.md
@@ -4,7 +4,7 @@ description: Choice of machines  for Sessions
 
 # Machines
 
-Here are the machines you can use to start up sessions. The syntax for this is numberOfAccelerators_acceleratorType_availableMemory.
+Here are the machines you can use to start up sessions. The syntax for this is numberOfAccelerators_acceleratorType_availableMemory. Below is an example utilizing this syntax to create a session on a machine with 8 v100 gpus and 32 GB memory.
 
 ```text
 grid session create --instance_type 8_v100_32gb

--- a/docs/products/sessions/machines.md
+++ b/docs/products/sessions/machines.md
@@ -4,7 +4,7 @@ description: Choice of machines  for Sessions
 
 # Machines
 
-Here are the machines you can use to start up sessions
+Here are the machines you can use to start up sessions. The syntax for this is numberOfAccelerators_acceleratorType_availableMemory.
 
 ```text
 grid session create --instance_type 8_v100_32gb


### PR DESCRIPTION
# What does this PR do?

In the current state it isn't explicitly stated how to use the machines table to select a machine type. This PR states explicitly how to read + understand the machine's table so users can use it within their CLI commands.

