### PR TITLE
updated path to datastore in release notes

### DIFF
--- a/changelog/2022-01-05.md
+++ b/changelog/2022-01-05.md
@@ -51,7 +51,7 @@ And the award for top FAQ goes to...
 
 With this release, accessing your data in a Session or Run is way more straightforward.
 
-After you’ve created a datastore, you can access it at `/datastores` in a Session or Run.
+After you’ve created a datastore, you can access it at `/datastore` in a Session or Run.
 
 More details on how to mount datastores:
 


### PR DESCRIPTION
# What does this PR do?

Update the default mount dir of datastores to `/datastore` instead of `/datastores` in release notes
