### PR TITLE
Replace trials with num_trials, add seed

### DIFF
--- a/docs/cli/api.md
+++ b/docs/cli/api.md
@@ -476,7 +476,8 @@ grid run [OPTIONS] [RUN_COMMAND]...
 | `--description` | text | Run description; useful for note-keeping | None |
 | `--cluster` | text | N/A | `prod-2` |
 | `--strategy` | choice (`grid_search` &#x7C; `random_search`) | Hyper-parameter search strategy | None |
-| `--trials` | integer | Number of trials to run hyper parameter search | None |
+| `--num_trials` | integer | Number of samples from full search space that are used by the random_search strategy | None |
+| `--seed` | integer | Seed value for the `random_search` strategy | None |
 | `--instance_type` | text | Instance type to start training session in | `t2.medium` |
 | `--gpus` | integer | Number of GPUs to allocate per experiment | `0` |
 | `--cpus` | integer | Number of CPUs to allocate per experiment | `1` |

--- a/docs/features/runs/sweep-syntax.md
+++ b/docs/features/runs/sweep-syntax.md
@@ -213,7 +213,7 @@ Using [Random Search](https://jmlr.csail.mit.edu/papers/volume13/bergstra12a/ber
 
 ```text
 grid run --strategy random_search \
-         --trials 3 \
+         --num_trials 3 \
          main.py \
          --alpha "uniform(1e-5, 1e-1, 3)" \
          --beta "[1, 2, 3, 4]"


### PR DESCRIPTION
# What does this PR do?

Random search does not use `trials` but `num_trials`. This corrects it
