### PR TITLE
Doc 278 our product parser is case sensitive for

### DIFF
--- a/docs/features/runs/sweep-syntax.md
+++ b/docs/features/runs/sweep-syntax.md
@@ -22,11 +22,13 @@ Passing in a flag without values is treated like a boolean
 grid run main.py --do_something
 ```
 
-Alternatively, your script can be written in such a way that it takes an arbitrary value and acts on them as booleans. For example, your script can be written in such a way that it treats 1/0, True, False, 'yes', 'no', etc as boolean values. This allows you to utilize arbitrary indicator hyperparameters in the Grid Search and Random Search features.
+Alternatively, your script can be written in such a way that it takes an arbitrary value and acts on them as booleans. For example, your script can be written in such a way that it treats 1/0, True, False, 'yes', 'no', etc as boolean values. For example:
 
 ```text
 grid run foo.py --bar 1 --barry 0
 ```
+
+This is the recommended syntax because it allows you to utilize arbitrary indicator hyperparameters in the Grid Search and Random Search features.
 
 ### float
 

--- a/docs/features/runs/sweep-syntax.md
+++ b/docs/features/runs/sweep-syntax.md
@@ -9,7 +9,7 @@ python main.py --layers 32 --learning_rate 0.01
 ```
 
 <note>
-This page provides a list of arguments specific to running hyperparameter sweeps. For the full Grid CLI API reference, visit [this page. ](../../cli/api.md)
+This page provides a list of arguments specific to running hyperparameter sweeps. For the full Grid CLI API reference, visit [this page](../../cli/api.md).
 </note>
 
 ## Python flags

--- a/docs/features/runs/sweep-syntax.md
+++ b/docs/features/runs/sweep-syntax.md
@@ -25,6 +25,10 @@ grid run main.py --do_something
 
 Alternatively, your script can be written in such a way that it takes integers and acts on them as booleans. For instance, using a 1 or 0 will default to True or False respectively.
 
+```text
+grid run foo.py --bar 1 --barry 0
+```
+
 ### float
 
 Grid supports standard float notation and scientific notation

--- a/docs/features/runs/sweep-syntax.md
+++ b/docs/features/runs/sweep-syntax.md
@@ -28,7 +28,11 @@ Alternatively, your script can be written in such a way that it takes an arbitra
 grid run foo.py --bar 1 --barry 0
 ```
 
-This is the recommended syntax because it allows you to utilize arbitrary indicator hyperparameters in the Grid Search and Random Search features.
+This is the recommended syntax because it allows you to utilize arbitrary indicator hyperparameters in the Grid Search and Random Search features. For example, the following will invoke a grid search.
+
+```text
+grid run foo.py --bar '[True, False]'
+```
 
 ### float
 

--- a/docs/features/runs/sweep-syntax.md
+++ b/docs/features/runs/sweep-syntax.md
@@ -22,7 +22,7 @@ Passing in a flag without values is treated like a boolean
 grid run main.py --do_something
 ```
 
-Alternatively, your script can be written in such a way that it takes integers and acts on them as booleans. For instance, using a 1 or 0 will default to True or False respectively.
+Alternatively, your script can be written in such a way that it takes an arbitrary value and acts on them as booleans. For example, your script can be written in such a way that it treats 1/0, True, False, 'yes', 'no', etc as boolean values. This allows you to utilize arbitrary indicator hyperparameters in the Grid Search and Random Search features.
 
 ```text
 grid run foo.py --bar 1 --barry 0

--- a/docs/features/runs/sweep-syntax.md
+++ b/docs/features/runs/sweep-syntax.md
@@ -28,7 +28,7 @@ Alternatively, your script can be written in such a way that it takes an arbitra
 grid run foo.py --bar 1 --barry 0
 ```
 
-This is the recommended syntax because it allows you to utilize arbitrary indicator hyperparameters in the Grid Search and Random Search features. For example, the following will invoke a grid search.
+This is the recommended syntax because it allows you to utilize arbitrary indicator hyperparameters in the [grid search](https://docs.grid.ai/features/runs/sweep-syntax#grid-search) and [random search](https://docs.grid.ai/features/runs/sweep-syntax#grid-search) features. For example, the following will invoke a grid search.
 
 ```text
 grid run foo.py --bar '[True, False]'

--- a/docs/features/runs/sweep-syntax.md
+++ b/docs/features/runs/sweep-syntax.md
@@ -13,7 +13,6 @@ This page provides a list of arguments specific to running hyperparameter sweeps
 </note>
 
 ## Python flags
-Under the hood we are using Argparse for parsing of Python flags and consequently inherit the same limitations it has. For example, there is a known limitation with parsing boolean values. See the official Argparse [documentation](https://docs.python.org/3/library/argparse.html#type). However, Grid still provides a way to easily pass in Boolean flags.
 
 ### boolean
 

--- a/docs/features/runs/sweep-syntax.md
+++ b/docs/features/runs/sweep-syntax.md
@@ -1,3 +1,5 @@
+import Note from "@site/src/components/Note";
+
 # Hyperparameter Sweeps
 
 Grid allows running [hyperparameter sweeps](https://www.grid.ai/what-are-hyperparameter-sweeps-and-why-are-they-important-to-production-machine-learning) without changing a single line of code! Just make sure your script can take arguments:
@@ -6,11 +8,12 @@ Grid allows running [hyperparameter sweeps](https://www.grid.ai/what-are-hyperpa
 python main.py --layers 32 --learning_rate 0.01
 ```
 
-:::note
+<note>
 This page provides a list of arguments specific to running hyperparameter sweeps. For the full Grid CLI API reference, visit [this page. ](../../cli/api.md)
-:::
+</note>
 
 ## Python flags
+Under the hood we are using Argparse for parsing of Python flags and consequently inherit the same limitations it has. For example, there is a known limitation with parsing boolean values. See the official Argparse [documentation](https://docs.python.org/3/library/argparse.html#type). However, Grid still provides a way to easily pass in Boolean flags.
 
 ### boolean
 
@@ -19,6 +22,8 @@ Passing in a flag without values is treated like a boolean
 ```text
 grid run main.py --do_something
 ```
+
+Alternatively, your script can be written in such a way that it takes integers and acts on them as booleans. For instance, using a 1 or 0 will default to True or False respectively.
 
 ### float
 

--- a/docs/features/runs/sweep-syntax.md
+++ b/docs/features/runs/sweep-syntax.md
@@ -28,7 +28,7 @@ Alternatively, your script can be written in such a way that it takes an arbitra
 grid run foo.py --bar 1 --barry 0
 ```
 
-This is the recommended syntax because it allows you to utilize arbitrary indicator hyperparameters in the [grid search](https://docs.grid.ai/features/runs/sweep-syntax#grid-search) and [random search](https://docs.grid.ai/features/runs/sweep-syntax#grid-search) features. For example, the following will invoke a grid search.
+This is the recommended syntax because it allows you to utilize arbitrary indicator hyperparameters in the [grid search](https://docs.grid.ai/features/runs/sweep-syntax#grid-search) and [random search](https://docs.grid.ai/features/runs/sweep-syntax#random-search) features. For example, the following will invoke a grid search.
 
 ```text
 grid run foo.py --bar '[True, False]'

--- a/docs/features/runs/sweep-syntax.md
+++ b/docs/features/runs/sweep-syntax.md
@@ -22,13 +22,13 @@ Passing in a flag without values is treated like a boolean
 grid run main.py --do_something
 ```
 
-Alternatively, your script can be written in such a way that it takes an arbitrary value and acts on them as booleans. For example, your script can be written in such a way that it treats 1/0, True, False, 'yes', 'no', etc as boolean values. For example:
+Alternatively, your script can be written in such a way that it takes an arbitrary value and acts on them as booleans. For example, your script can be written in such a way that it treats 1/0, True/False, 'yes'/'no', etc as boolean values. For example:
 
 ```text
 grid run foo.py --bar 1 --barry 0
 ```
 
-This is the recommended syntax because it allows you to utilize arbitrary indicator hyperparameters in the [grid search](https://docs.grid.ai/features/runs/sweep-syntax#grid-search) and [random search](https://docs.grid.ai/features/runs/sweep-syntax#random-search) features. For example, the following will invoke a grid search.
+This is the recommended syntax because it allows you to utilize arbitrary indicator hyperparameters in the [grid search](https://docs.grid.ai/features/runs/sweep-syntax#grid-search) and [random search](https://docs.grid.ai/features/runs/sweep-syntax#random-search) features. For example, the following will invoke a grid search:
 
 ```text
 grid run foo.py --bar '[True, False]'


### PR DESCRIPTION
# What does this PR do?

This PR adds a best practice example for passing in booleans in Python scripts. This ensures users won't run into errors when it comes to parsing boolean flags.
