### PR TITLE
fix typo + remove --source syntax

### DIFF
--- a/docs/features/runs/attaching-datastores.md
+++ b/docs/features/runs/attaching-datastores.md
@@ -4,7 +4,7 @@
 
 <!-- ![](/images/data.gif) -->
 
-You can mount a datastore to a run to make your experiments run faster! By default, the datastore is mounted at /datastore. When attaching datastores to a run, take note of the path your script uses. For example if your script takes an argument _my_data_path_ and you want to mount the _cats_ datastore:
+You can mount a datastore to a run to make your experiments run faster! By default, the datastore is mounted at /datastores. When attaching datastores to a run, take note of the path your script uses. For example if your script takes an argument _my_data_path_ and you want to mount the _cats_ datastore:
 
 ```bash
 grid run main.py --my_data_path /datastores/cats/1
@@ -41,7 +41,7 @@ val = load(root + 'val')
 When you upload a datastore to Grid:
 
 ```bash
-grid datastore create --source my_dataset --name apples
+grid datastore create my_dataset
 ```
 
 it is available under this structure:


### PR DESCRIPTION
# What does this PR do?

Simple PR to fix a typo I recently identified in the runs/attach_datastores.md. It also removes mention of the --source syntax from there as the has been removed with the 0.8.1 release.
