### PR TITLE
removed datastore source param

### DIFF
--- a/docs/cli/api.md
+++ b/docs/cli/api.md
@@ -191,7 +191,6 @@ grid datastore create [OPTIONS]
 
 | Name | Type | Description | Default |
 | ---- | ---- | ----------- | ------- |
-| `--source` | text | Source to create datastore from. This could either be a local directory (e.g: /opt/local_folder) or a remote HTTP URL pointing to a TAR file (e.g: http://some_domain/data.tar.gz). |  |
 | `--name` | text | Name of the datastore | None |
 | `--compression` | boolean | Compresses datastores with GZIP when flag is passed. | `False` |
 | `--cluster` | text | cluster id to create the datastore on. (Bring Your Own Cloud Customers Only). | None |

--- a/docs/features/datastores/create.md
+++ b/docs/features/datastores/create.md
@@ -35,7 +35,7 @@ grid login
 Next, use the datastores command to upload any folder:
 
 ```bash
-grid datastore create --source imagenet_folder --name imagenet
+grid datastore create imagenet_folder --name imagenet
 ```
 
 Note that you will need at least as much free space as the size of your dataset on the disk hosting your home folder, for the internal preparation of the upload.


### PR DESCRIPTION
# What does this PR do?

- manually removes --source param from CLI API docs (separate PR for grid monorepo has been filed)
- removed --source param from general documentation
