### PR TITLE
doc-120-we-should-update-the-docs-that

### DIFF
--- a/docs/features/runs/running-experiments-with-a-dockerfile.md
+++ b/docs/features/runs/running-experiments-with-a-dockerfile.md
@@ -4,7 +4,7 @@ description: Use your own Dockerfile files when creating experiments in Grid.
 
 # Running Experiments With a Dockerfile
 
-Grid supports the creation of Runs using `Dockerfile` files. Dockerfiles are a container specification that determines how images are be built. You can find documentation about Dockerfiles [here](https://docs.docker.com/engine/reference/builder). When using this option the requirements.txt in the root project directory is ignored. Unless explicity mentioned in a RUN command within the Dockerfile.
+Grid supports the creation of Runs using `Dockerfile` files. Dockerfiles are a container specification that determines how images are be built. You can find documentation about Dockerfiles [here](https://docs.docker.com/engine/reference/builder). When using this option, the requirements.txt file in the root project directory is ignored unless explicity stated in a RUN command within the Dockerfile.
 
 ### Step 0: Create a Dockerfile
 

--- a/docs/features/runs/running-experiments-with-a-dockerfile.md
+++ b/docs/features/runs/running-experiments-with-a-dockerfile.md
@@ -4,7 +4,7 @@ description: Use your own Dockerfile files when creating experiments in Grid.
 
 # Running Experiments With a Dockerfile
 
-Grid supports the creation of Runs using `Dockerfile` files. Dockerfiles are a container specification that determines how images are be built. You can find documentation about Dockerfiles [here](https://docs.docker.com/engine/reference/builder). When using this option the requirements.txt in the root project directory is ignored.
+Grid supports the creation of Runs using `Dockerfile` files. Dockerfiles are a container specification that determines how images are be built. You can find documentation about Dockerfiles [here](https://docs.docker.com/engine/reference/builder). When using this option the requirements.txt in the root project directory is ignored. Unless explicity mentioned in a RUN command within the Dockerfile.
 
 ### Step 0: Create a Dockerfile
 

--- a/docs/features/runs/running-experiments-with-a-dockerfile.md
+++ b/docs/features/runs/running-experiments-with-a-dockerfile.md
@@ -4,7 +4,7 @@ description: Use your own Dockerfile files when creating experiments in Grid.
 
 # Running Experiments With a Dockerfile
 
-Grid supports the creation of Runs using `Dockerfile` files. Dockerfiles are a container specification that determines how images are be built. You can find documentation about Dockerfiles [here](https://docs.docker.com/engine/reference/builder).
+Grid supports the creation of Runs using `Dockerfile` files. Dockerfiles are a container specification that determines how images are be built. You can find documentation about Dockerfiles [here](https://docs.docker.com/engine/reference/builder). When using this option the requirements.txt in the root project directory is ignored.
 
 ### Step 0: Create a Dockerfile
 


### PR DESCRIPTION
# What does this PR do?

Adds note that when the --dockerfile flag is used the requirements.txt within the root directory is ignored.
