### PR TITLE
fix broken GitHub links

### DIFF
--- a/docs/features/sessions/github-login.md
+++ b/docs/features/sessions/github-login.md
@@ -3,7 +3,7 @@ description: Automatic login to Github in a Session
 ---
 
 # GitHub Integration
-See [here](https://docs.grid.ai/platformgithub-integration) for detailed steps on how to integrate GitHub with Grid.
+See [here](https://docs.grid.ai/platform/github-integration) for detailed steps on how to integrate GitHub with Grid.
 
 # Github login
 

--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -40,7 +40,7 @@ To get the full power of Grid, it is important to integrate your Github account 
 
 ## Github Integration
 
-See [here](https://docs.grid.ai/platformgithub-integration) for detailed steps on how to integrate Grid with GitHub.
+See [here](https://docs.grid.ai/platform/github-integration) for detailed steps on how to integrate Grid with GitHub.
 
 # Tutorials
 


### PR DESCRIPTION
# What does this PR do?

fix broken GitHub links on the Runs and Sessions pages.
