### PR TITLE
remove mention of private s3 bucket access for byoc users

### DIFF
--- a/docs/features/datastores/README.md
+++ b/docs/features/datastores/README.md
@@ -17,33 +17,6 @@ Datastores can be attached to Runs or Sessions and preserve the file format and 
 We don't charge for data storage!
 :::
 
-## Datastores with Private S3 Buckets
-
-At this time we are only supporting usage of private S3 buckets as datastores for BYOC users, who have connected Grid to a custom AWS cluster. You can grant Grid access to your desired buckets by following the official aws [documentation](https://aws.amazon.com/premiumsupport/knowledge-center/cross-account-access-s3/).
-
-As a convenience, below we provided a bucket policy that grants Grid access to all the contents of your specified bucket. It assumes that you modified the tfvars role_arn field. If you have not then you can use `<aws-account-id-associated-with-byoc>:root` instead. You can follow this official aws [documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html) to get your account id.
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam::<aws-account-id-associated-with-byoc>:role/role-name"
-            },
-            "Action": [
-                "s3:ListBucket",
-                "s3:GetObject",
-                "s3:GetBucketLocation"
-            ],
-            "Resource": [
-               "arn:aws:s3:::<your-bucket>/*",
-               "arn:aws:s3:::<your-bucket>"
-           ]               
-        }
-    ]
-}
-```
 ## Product Tour
 
 Upload data to Grid using Datastores. Datastores are low-latency, auto-versioned datasets.


### PR DESCRIPTION
# What does this PR do?

Removes private s3 docs from datastores readme since this functionality does not work. 
