### PR TITLE
Feature(cli) GRID-8908: Added docs about `--no-copy` for CLI datastore creation flow

### DIFF
--- a/docs/features/datastores/2_Using Datastores/2_creating-datastores.md
+++ b/docs/features/datastores/2_Using Datastores/2_creating-datastores.md
@@ -104,6 +104,9 @@ grid datastore create s3://ryft-public-sample-data/esRedditJson/ --name lightnin
 
 ### Using the `--no-copy` option via the CLI
 
+Example: 
+`grid datastore create S3://ruff-public-sample-data/esRedditJson --no-copy`
+
 In certain cases, your s3 bucket may fit one (or both) of the following criteria: (1)
 the bucket is continually updating with new data which you want included in a Grid datastore (2) the bucket is
 particularly large (leading to long Datastore creation times). In these cases,

--- a/docs/features/datastores/2_Using Datastores/2_creating-datastores.md
+++ b/docs/features/datastores/2_Using Datastores/2_creating-datastores.md
@@ -31,7 +31,13 @@ For datasets larger than 1 GB, use the CLI.
 
 :::note 
 
-If you have a dataset that is 1GB+ and poor-average internet connection, we suggest starting an Interactive Session and creating the Datastore from there. Internet speed is much faster in Interactive Sessions, so upload times will be shorter. 
+We suggest starting an Interactive Session and creating your Datastore from there in the following instances:
+
+- Your dataset is larger than 1GB
+- You do not have a strong internet connection
+
+Using an Interactive Session in this scenario will improve your upload speed.
+
 
 :::
 
@@ -107,18 +113,21 @@ grid datastore create s3://ryft-public-sample-data/esRedditJson/ --name lightnin
 Example: 
 `grid datastore create S3://ruff-public-sample-data/esRedditJson --no-copy`
 
-In certain cases, your s3 bucket may fit one (or both) of the following criteria: (1)
-the bucket is continually updating with new data which you want included in a Grid datastore (2) the bucket is
-particularly large (leading to long Datastore creation times). In these cases,
-you can pass the `--no-copy` flag to the `grid datastore create` command. This flag will
-prevent grid from making a copy of the dataset, speeding up datastore creation time
-significantly when working with large buckets. 
+In certain cases, your S3 bucket may fit one (or both) of the following criteria:
+
+(1) the bucket is continually updating with new data which you want included in a Grid Datastore 
+(2) the bucket is particularly large (leading to long Datastore creation times)
+
+In these cases, you can pass the `--no-copy` flag to the `grid datastore create` command. This flag will
+prevent Grid from making a copy of the dataset, which significantly speeds up Datastore creation time.
 
 :::info 
 
-When using this flag, you cannot remove files from your bucket. If you'd like to add files, please create a new version of the datastore after you've added files to your bucket. Please note that Grid does not currently support private S3 buckets. 
+When using this flag, you cannot remove files from your bucket. If you'd like to add files, please create a new version of the Datastore after you've added files to your bucket. 
 
-If using this flag via the grid public cloud, then the source bucket should be in the  AWS `us-east-1` region or there will be significant latency when you attempt to access the datastore files in a run / session. 
+Please note that Grid does not currently support private S3 buckets. 
+
+If you are using this flag via the Grid public cloud, then the source bucket should be in the  AWS `us-east-1` region or there will be significant latency when you attempt to access the Datastore files in a Run or Session.
 
 :::
 

--- a/docs/features/datastores/2_Using Datastores/2_creating-datastores.md
+++ b/docs/features/datastores/2_Using Datastores/2_creating-datastores.md
@@ -102,7 +102,7 @@ grid datastore create s3://ryft-public-sample-data/esRedditJson/ --name lightnin
 
 :::
 
-#### Using the `--no-copy` option
+### Using the `--no-copy` option via the CLI
 
 In certain cases you you may be presented with an s3 bucket which is either: (1)
 continually updating with new data you want included in a Grid datastore (2) is
@@ -111,14 +111,15 @@ you can pass the `--no-copy` flag to the `grid datastore create` command. This f
 prevent grid from making a copy of the dataset, speeding up datastore creation time
 significantly when working with large buckets. 
 
-::: note 
+:::info 
 
 When using this flag, you cannot remove files from your bucket. If you'd like to add.
 files, please create a new version of the datastore after you've added files to your.
-bucket. Please note that Grid does not currently support private S3 buckets. If using this
-flag via the grid public cloud, then the source bucket should be in the AWS `us-east-1`
-region or there will be significant latency when you attempt to access the datastore files
-in a run / session. 
+bucket. Please note that Grid does not currently support private S3 buckets. 
+
+If using this flag via the grid public cloud, then the source bucket should be in the 
+AWS `us-east-1` region or there will be significant latency when you attempt to access
+the datastore files in a run / session. 
 
 :::
 

--- a/docs/features/datastores/2_Using Datastores/2_creating-datastores.md
+++ b/docs/features/datastores/2_Using Datastores/2_creating-datastores.md
@@ -31,7 +31,7 @@ For datasets larger than 1 GB, use the CLI.
 
 :::note 
 
-If you have a dataset that is 1Gb+ and poor-average internet connection, we suggest starting an Interactive Session and creating the Datastore from there. Internet speed is much faster in Interactive Sessions, so upload times will be shorter. 
+If you have a dataset that is 1GB+ and poor-average internet connection, we suggest starting an Interactive Session and creating the Datastore from there. Internet speed is much faster in Interactive Sessions, so upload times will be shorter. 
 
 :::
 
@@ -99,6 +99,26 @@ datastore from this bucket named `"lightning-train-data"` we could execute:
 ```bash
 grid datastore create s3://ryft-public-sample-data/esRedditJson/ --name lightning-train-data
 ```
+
+:::
+
+#### Using the `--no-copy` option
+
+In certain cases you you may be presented with an s3 bucket which is either: (1)
+continually updating with new data you want included in a Grid datastore (2) is
+particularly large (taking a long time to create via the normal method). In these cases,
+you can pass the `--no-copy` flag to the `grid datastore create` command. This flag will
+prevent grid from making a copy of the dataset, speeding up datastore creation time
+significantly when working with large buckets. 
+
+::: note 
+
+When using this flag, you cannot remove files from your bucket. If you'd like to add.
+files, please create a new version of the datastore after you've added files to your.
+bucket. Please note that Grid does not currently support private S3 buckets. If using this
+flag via the grid public cloud, then the source bucket should be in the AWS `us-east-1`
+region or there will be significant latency when you attempt to access the datastore files
+in a run / session. 
 
 :::
 

--- a/docs/features/datastores/2_Using Datastores/2_creating-datastores.md
+++ b/docs/features/datastores/2_Using Datastores/2_creating-datastores.md
@@ -104,22 +104,18 @@ grid datastore create s3://ryft-public-sample-data/esRedditJson/ --name lightnin
 
 ### Using the `--no-copy` option via the CLI
 
-In certain cases you you may be presented with an s3 bucket which is either: (1)
-continually updating with new data you want included in a Grid datastore (2) is
-particularly large (taking a long time to create via the normal method). In these cases,
+In certain cases, your s3 bucket may fit one (or both) of the following criteria: (1)
+the bucket is continually updating with new data which you want included in a Grid datastore (2) the bucket is
+particularly large (leading to long Datastore creation times). In these cases,
 you can pass the `--no-copy` flag to the `grid datastore create` command. This flag will
 prevent grid from making a copy of the dataset, speeding up datastore creation time
 significantly when working with large buckets. 
 
 :::info 
 
-When using this flag, you cannot remove files from your bucket. If you'd like to add.
-files, please create a new version of the datastore after you've added files to your.
-bucket. Please note that Grid does not currently support private S3 buckets. 
+When using this flag, you cannot remove files from your bucket. If you'd like to add files, please create a new version of the datastore after you've added files to your bucket. Please note that Grid does not currently support private S3 buckets. 
 
-If using this flag via the grid public cloud, then the source bucket should be in the 
-AWS `us-east-1` region or there will be significant latency when you attempt to access
-the datastore files in a run / session. 
+If using this flag via the grid public cloud, then the source bucket should be in the  AWS `us-east-1` region or there will be significant latency when you attempt to access the datastore files in a run / session. 
 
 :::
 


### PR DESCRIPTION
# What does this PR do?

Added docs about `grid datastore create s3://foo --no-copy` option when creating datastores from public s3 buckets via the CLI. 