### PR TITLE
update instance type

### DIFF
--- a/docs/getting-started/getting-started-with-grid.md
+++ b/docs/getting-started/getting-started-with-grid.md
@@ -4,7 +4,7 @@ title: Getting Started with Grid
 ---
 
 :::tip
-For all code snippets you can modify the instance type yo suit your needs. Please see the
+For all code snippets you can modify the instance type to suit your needs. Please see the
 [billings page](../platform/1_billing/billing-rates.md) for machine options and price and
 the [machines page](../platform/3_machines.md#recommended-instance-types) for recommended
  machine types.

--- a/docs/getting-started/getting-started-with-grid.md
+++ b/docs/getting-started/getting-started-with-grid.md
@@ -3,6 +3,13 @@ sidebar_position: 1
 title: Getting Started with Grid
 ---
 
+:::tip
+For all code snippets you can modify the instance type yo suit your needs. Please see the
+[billings page](../platform/1_billing/billing-rates.md) for machine options and price and
+the [machines page](../platform/3_machines.md#recommended-instance-types) for recommended
+ machine types.
+:::
+
 # Grid Installation
 
 ## Prerequisites

--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -205,7 +205,7 @@ Start a Session named _**resnet-debugging**_ **\*\*with 2 M60 GPUs on it and att
 
 ```yaml
 grid session create \
---instance_type g3.8xlarge \
+--instance_type g4dn.xlarge \
 --name resnet-debugging \
 --datastore_name cifar5 \
 --datastore_version 1
@@ -265,7 +265,7 @@ git push
 
 \(Time: **5 minutes**\)
 
-Now that you have your data, code, and 2 GPUs, we get to the fun part! Let's develop the model
+Now that you have your data, code, and 1 GPU, we get to the fun part! Let's develop the model
 
 At the end of the last section you used ssh to make model changes. However, I actually prefer to use VSCode for this. Let's set up VSCode to code directly on the remote machine.
 
@@ -323,7 +323,8 @@ now run the following command to train a resnet18 on 2 GPUs
 ```bash
 python flash-image-classifier.py \
       --data_dir /datastores/cifar5 \
-      --gpus 2 \
+      --instance_type g4dn.xlarge \
+      --gpus 1 \
       --epochs 4
 ```
 
@@ -382,13 +383,13 @@ Now kick off the run with grid run
 ```bash
 grid run --dependency_file ./requirements.txt \
          --name cifar-tut-hpo \
-         --instance_type g4dn.12xlarge \
+         --instance_type g4dn.xlarge \
          --datastore_name cifar5 \
          --datastore_version 1 \
          -- \
          flash-image-classifier.py \
          --data_dir /datastores/cifar5 \
-         --gpus 4 \
+         --gpus 1 \
          --epochs 4 \
          --learning_rate "uniform(1e-5, 1e-1, 5)"
 ```

--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -375,13 +375,13 @@ Now kick off the run with grid run
 ```bash
 grid run --dependency_file ./requirements.txt \
          --name cifar-tut-hpo \
-         --instance_type 2_m60_8gb \
+         --instance_type g4dn.12xlarge \
          --datastore_name cifar5 \
          --datastore_version 1 \
          -- \
          flash-image-classifier.py \
          --data_dir /datastores/cifar5 \
-         --gpus 2 \
+         --gpus 4 \
          --epochs 4 \
          --learning_rate "uniform(1e-5, 1e-1, 5)"
 ```

--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -388,7 +388,7 @@ grid run --dependency_file ./requirements.txt \
 
 :::note
 You can do this from the Session or your local machine \(but you'll need to clone the project locally\). In the above code you can
-also change the instance type to any one that suits your needs. Please see the [billings page](../../platform/1_billing/billing-rates.md) for machine options and price.
+also change the instance type to any one that suits your needs. Please see the [billings page](../platform/1_billing/billing-rates.md) for machine options and price.
 :::
 
 ## **Bonus: Use a YAML for common runs**

--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -387,9 +387,7 @@ grid run --dependency_file ./requirements.txt \
 ```
 
 :::note
-You can do this from the Session or your local machine \(but you'll need to clone the project locally\). In the above code you can
-also change the instance type to any one that suits your needs. Please see the [billings page](../platform/1_billing/billing-rates.md)
-for machine options and price. Additionally, ensure that the gpu field matches the number of GPU's available for the machine selected.
+You can do this from the Session or your local machine \(but you'll need to clone the project locally\). 
 :::
 
 ## **Bonus: Use a YAML for common runs**

--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -387,7 +387,8 @@ grid run --dependency_file ./requirements.txt \
 ```
 
 :::note
-You can do this from the Session or your local machine \(but you'll need to clone the project locally\)
+You can do this from the Session or your local machine \(but you'll need to clone the project locally\). In the above code you can
+also change the instance type to any one that suits your needs. Please see the (billings page)[../../platform/1_billing/billing-rates.md] for machine options and price.
 :::
 
 ## **Bonus: Use a YAML for common runs**

--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -3,6 +3,13 @@ sidebar_position: 11
 description: Using the command line interface
 ---
 
+:::tip
+For all code snippets you can modify the instance type yo suit your needs. Please see the
+[billings page](../platform/1_billing/billing-rates.md) for machine options and price and
+the [machines page](../platform/3_machines.md#recommended-instance-types) for recommended
+ machine types.
+:::
+
 # Typical workflow (CLI user)
 
 ## Goal

--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -4,7 +4,7 @@ description: Using the command line interface
 ---
 
 :::tip
-For all code snippets you can modify the instance type yo suit your needs. Please see the
+For all code snippets you can modify the instance type to suit your needs. Please see the
 [billings page](../platform/1_billing/billing-rates.md) for machine options and price and
 the [machines page](../platform/3_machines.md#recommended-instance-types) for recommended
  machine types.

--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -388,7 +388,7 @@ grid run --dependency_file ./requirements.txt \
 
 :::note
 You can do this from the Session or your local machine \(but you'll need to clone the project locally\). In the above code you can
-also change the instance type to any one that suits your needs. Please see the (billings page)[../../platform/1_billing/billing-rates.md] for machine options and price.
+also change the instance type to any one that suits your needs. Please see the [billings page](../../platform/1_billing/billing-rates.md) for machine options and price.
 :::
 
 ## **Bonus: Use a YAML for common runs**

--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -388,7 +388,8 @@ grid run --dependency_file ./requirements.txt \
 
 :::note
 You can do this from the Session or your local machine \(but you'll need to clone the project locally\). In the above code you can
-also change the instance type to any one that suits your needs. Please see the [billings page](../platform/1_billing/billing-rates.md) for machine options and price.
+also change the instance type to any one that suits your needs. Please see the [billings page](../platform/1_billing/billing-rates.md)
+for machine options and price. Additionally, ensure that the gpu field matches the number of GPU's available for the machine selected.
 :::
 
 ## **Bonus: Use a YAML for common runs**

--- a/docs/getting-started/typical-workflow-web-user.md
+++ b/docs/getting-started/typical-workflow-web-user.md
@@ -4,6 +4,13 @@ description: "Using the web based application https://platform.grid.ai"
 ---
 import Video from "@site/src/components/Video";
 
+:::tip
+For all code snippets you can modify the instance type yo suit your needs. Please see the
+[billings page](../platform/1_billing/billing-rates.md) for machine options and price and
+the [machines page](../platform/3_machines.md#recommended-instance-types) for recommended
+ machine types.
+:::
+
 # Typical workflow (Web user)
 
 ## Goal


### PR DESCRIPTION
# What does this PR do?  

Updates instance types used in the tutorials to cheaper or more available ones. Waiting on confirmation from team on which instances are more readily available. It also adds a note detailing that the instance type can be customized but cautions users to match the gpu specification to that of the instance requested.

Explain purpose of PR and any useful context.
