### PR TITLE
doc-379-improve-yaml-documentation

### DIFF
--- a/docs/features/runs/17_yaml-configs/2_yaml-api.md
+++ b/docs/features/runs/17_yaml-configs/2_yaml-api.md
@@ -30,10 +30,20 @@ compute:
     datastore_mount_dir: null     # Where to mount the datastore
     use_spot: false               # If we should use spot instances
     framework: "lightning"        # Which framework to use
+    dependency_file_info:         
+      package_manager: pip        # Either conda or pip
+      path: null                  # Path to the reqs or conda env
 
     # Pass in environment variables
     environment:
       MY_ENVIRONMENT_VARIABLE: "example"
+  
+hyper_params:
+  # your hyper params here
+  params:
+    # your params here
+    --foo: 1
+    -bar: 2
 ```
 
 :::note


### PR DESCRIPTION
# What does this PR do?

Adds additional keys that are usable in the config.yaml. The added keys are below

```
    dependency_file_info:         
      package_manager: pip        # Either conda or pip
      path: null                  # Path to the reqs or conda env
  
hyper_params:
  # your hyper params here
  params:
    # your params here
    --foo: 1
    -bar: 2

```