### PR TITLE
Fix broken links

### DIFF
--- a/docs/features/datastores/2_Using Datastores/3_inspecting_status.md
+++ b/docs/features/datastores/2_Using Datastores/3_inspecting_status.md
@@ -22,7 +22,7 @@ Processing times follow these general trends for each source type:
   the source bucket and the total size of the datastore. For small datastore sizes,
   (1-30GB), this process generally completes in less than 5 minutes. For larger, yet
   reasonably sized datasets (less than the [current maximum datastore
-  size](../faq.md#datastore-size-limit)), this process can take up to half an hour.
+  size](../3_faq.md#datastore-size-limit)), this process can take up to half an hour.
 
 
 ## Inspecting Datastore Status Using the CLI

--- a/docs/features/runs/1_Creating Runs/1_Basic Runs/2_basic-runs.md
+++ b/docs/features/runs/1_Creating Runs/1_Basic Runs/2_basic-runs.md
@@ -75,7 +75,7 @@ Explore the build logs to compare the logs of this Run to that of the vanilla Ru
 For instructions on how to view the logs check out [viewing logs produced by Runs](https://docs.grid.ai/features/runs/Analyzing%20Runs/viewing-logs).
 
 ## Attaching Datastores to Runs
-When working with large datasets, it may be faster and easier to store your data in a [Datastore](../../../datastores/1_README.md). Datastores are high-performance, low-latency, versioned, and scalable datasets which can be instantly mounted to any Session or Run.
+When working with large datasets, it may be faster and easier to store your data in a [Datastore](../../../datastores/README.md). Datastores are high-performance, low-latency, versioned, and scalable datasets which can be instantly mounted to any Session or Run.
 
 :::note
 By default, Datastores are mounted at /datastores on a Session or Run.

--- a/docs/platform/2_Custom Cloud Credentials/3_adding-custom-cloud-credentials.md
+++ b/docs/platform/2_Custom Cloud Credentials/3_adding-custom-cloud-credentials.md
@@ -93,7 +93,7 @@ Make sure that your username has the right policies attached in order to user Gr
 The created user and fetched credentials for should have IAMFullAccess privileges.
 
 :::note
-Reach out to us via [Slack](http://gridai-community.slack.com) or [email](support@grid.ai) if you have any issues creating the following AWS roles and policies. We're happy to help!
+Reach out to us via [Slack](http://gridai-community.slack.com) or [email](mailto:support@grid.ai) if you have any issues creating the following AWS roles and policies. We're happy to help!
 :::
 
 #### A: Add Policies to Your Account


### PR DESCRIPTION
# What does this PR do?

A few places had broken links, where users could click and receive a 404. Now they actually link to the correct page. This also fixes the build warnings from Docusaurus

Note: in 3_faq.md there is no longer a section for datastore-size-limit, and I could not find it in the current version of the docs anywhere. The link will still go to the FAQ though. We might want to update/rephrase 