### PR TITLE
Fixed ssh command required for connection to session

### DIFF
--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -222,10 +222,10 @@ Once the session is ready, you have three options to interact with it:
 - ssh from your local
 - ssh + VSCode
 
-Let's login to the Session via SSH.
+Let's login to the Session via SSH using previously added key.
 
 ```yaml
-grid session ssh resnet-debugging
+grid session ssh resnet-debugging -- -i ~/.ssh/grid_ssh_creds
 ```
 
 Now you're on the cloud machine! See how many GPUs you have

--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -174,6 +174,12 @@ You need to do this step **only once**
 # make the ssh key (if you don't have one)
 ssh-keygen -b 2048 -t rsa -f ~/.ssh/grid_ssh_creds -q -N ""
 
+# add the key to the ssh-agent (to avoid having to explicitly state key on each connection)
+# to start the agent, run the following
+eval $(ssh-agent)
+# then add the key
+ssh-add  ~/.ssh/grid_ssh_creds
+
 # add the keys to grid
 grid ssh-keys add key_1 ~/.ssh/grid_ssh_creds.pub
 ```
@@ -222,10 +228,10 @@ Once the session is ready, you have three options to interact with it:
 - ssh from your local
 - ssh + VSCode
 
-Let's login to the Session via SSH using the previously added key.
+Let's login to the Session via SSH. 
 
 ```yaml
-grid session ssh resnet-debugging -- -i ~/.ssh/grid_ssh_creds
+grid session ssh resnet-debugging
 ```
 
 Now you're on the cloud machine! See how many GPUs you have

--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -222,7 +222,7 @@ Once the session is ready, you have three options to interact with it:
 - ssh from your local
 - ssh + VSCode
 
-Let's login to the Session via SSH using previously added key.
+Let's login to the Session via SSH using the previously added key.
 
 ```yaml
 grid session ssh resnet-debugging -- -i ~/.ssh/grid_ssh_creds


### PR DESCRIPTION
# What does this PR do?

Following directly step-by-step commands from tutorial results in error upon ssh connection.
On connection we should specify the ssh-key to use for establishment of that connection ie. private key for the public key that was added with `grid ssh-keys add key_1 ~/.ssh/grid_ssh_creds.pub`
It should be `grid session ssh resnet-debugging -- -i ~/.ssh/grid_ssh_creds`
