### PR TITLE
add missing name to code block

### DIFF
--- a/docs/features/runs/1_Creating Runs/2_Adv Runs/5_auto-resume-experiments.md
+++ b/docs/features/runs/1_Creating Runs/2_Adv Runs/5_auto-resume-experiments.md
@@ -44,7 +44,7 @@ In order for experiments to resume from last checkpoint, the following prerequis
 Use `--auto_resume` flag to indicate this experiment is safe to resume.
 
 ```bash
-grid run --use_spot --auto_resume --instance_type p3.2xlarge mnist.py
+grid run --name [run-to-resume] --use_spot --auto_resume --instance_type p3.2xlarge mnist.py
 ```
 
 


### PR DESCRIPTION
# What does this PR do?

Adds name to code block. Currently there is no identifier in the code to signify which Run to resume.
