### PR TITLE
Doc 387 remove the known issues for artifacts

### DIFF
--- a/docs/platform/10_known-issues.md
+++ b/docs/platform/10_known-issues.md
@@ -11,13 +11,11 @@ sidebar_label: Known Issues
 * Creating runs with the same name across two cluster is currenly supported, but prohibits certain operations against runs/experiments.
 
 ### [Artifacts](https://docs.grid.ai/features/runs/artifacts)
-* Artifacts don't sync for fast experiments: We have detected a race condition with short-running experiments, which may cause artifacts not to be properly synced. We recommend ensuring your experiments last at least a minute (to be safe). You can add sleep if needed as a workaround.
-
 * Canceling download of Artifacts: When downloading the artifacts, Ctrl-C does not cancel the download. As a workaround, use Ctrl-Z followed by `kill -9 $(jobs -p)`.
 
 
 ### [Collaboration](https://docs.grid.ai/platform/collaboration)
-* Downloading artifacts and/or viewing logs from a teammate's experiments is not supported from the CLI. Please use the UI as a workaround.
+* Downloading artifacts from a teammate's experiments is not supported from the CLI. Please use the UI as a workaround.
 
 ### [Datastore](https://docs.grid.ai/features/datastores)
 * grid datastore [create](https://docs.grid.ai/features/datastores/create) ./cifar10


### PR DESCRIPTION
# What does this PR do?
Doc 387 remove the known issues for artifacts
Team mates can view logs for other team mates

Explain purpose of PR and any useful context.
