### PR TITLE
add G5g series to unsupported BYOC

### DIFF
--- a/docs/platform/10_known-issues.md
+++ b/docs/platform/10_known-issues.md
@@ -9,7 +9,7 @@ sidebar_label: Known Issues
 
 ### [BYOC](https://docs.grid.ai/platform/custom-cloud-credentials/byoc)
 * Creating runs with the same name across two cluster is currenly supported, but prohibits certain operations against runs/experiments.
-* BYOC can only support instance types with the x86_64 architecture. The instance families of the following instance types are known to not be supported due to their architecture: A1, T4g, M6g, C6g, and R6g.
+* BYOC can only support instance types with the x86_64 architecture. The instance families of the following instance types are known to not be supported due to their architecture: A1, T4g, M6g, C6g, G5g, and R6g.
 
 ### [Collaboration](https://docs.grid.ai/platform/collaboration)
 * Downloading artifacts from a teammate's experiments is not supported from the CLI. Please use the UI as a workaround.


### PR DESCRIPTION
# What does this PR do?

Adds the G5g series to our unsupported BYOC instance types.
