### PR TITLE
Update datastore param for `run`

### DIFF
--- a/docs/features/runs/1_Creating Runs/1_Basic Runs/2_basic-runs.md
+++ b/docs/features/runs/1_Creating Runs/1_Basic Runs/2_basic-runs.md
@@ -99,7 +99,7 @@ Once the datastore has been successfully created, you can mount it to a Run usin
 ```text
 git clone https://github.com/PyTorchLightning/grid-tutorials.git
 cd grid-tutorials/features-intro/runs
-grid run --name attaching-datastore --datastore_name cifar5 --datastore_version 1 datastore.py --data_dir /datastores/cifar5/1
+grid run --name attaching-datastore --datastore_name cifar5 --datastore_version 1 datastore.py --datastore_mount_dir /datastores/cifar5/1
 ```
 
 The above code passes a script named `datastore.py` to the Run. This script prints the contents of the Datastores root directory. You should see the following output in your stdout logs.


### PR DESCRIPTION
# What does this PR do?

The `--data_dir` doesn't seem to exist in `0.8.6.4`

