### PR TITLE
update about default cpus

### DIFF
--- a/changelog/2022-06-24.md
+++ b/changelog/2022-06-24.md
@@ -1,0 +1,14 @@
+## :warning: June 24, 2022
+
+**CLI version: 0.8.65 **
+
+This release includes an important update to how CPU and memory are allocated to experiments.  
+
+Prior to this release, Grid would set the default number of CPUs to 1 when creating runs and not explictly specifying `--cpus`.
+
+We recently discovered an issue with runs where setting `--cpus` 1 would also reduce the memory, causing lots of OOM issues.
+
+So we've updated this behavior to set `--cpus` to 0 by default. This applies when creating runs with GPUs as well. By setting `--cpus` to 0, the backend will allocate all available CPU and memory to the experiment.
+
+
+---

--- a/changelog/2022-06-24.md
+++ b/changelog/2022-06-24.md
@@ -6,7 +6,7 @@ This release includes an important update to how CPU and memory are allocated to
 
 Prior to this release, Grid would set the default number of CPUs to 1 when creating runs and not explictly specifying `--cpus`.
 
-We recently discovered an issue with runs where setting `--cpus` 1 would also reduce the memory, causing lots of OOM issues.
+We recently discovered an issue with runs where setting `--cpus` to 1 would also reduce the memory, causing lots of OOM issues.
 
 So we've updated this behavior to set `--cpus` to 0 by default. This applies when creating runs with GPUs as well. By setting `--cpus` to 0, the backend will allocate all available CPU and memory to the experiment.
 


### PR DESCRIPTION
# What does this PR do?

Adds change in default `--cpus` to release notes
