### PR TITLE
Improve installation steps

### DIFF
--- a/docs/getting-started/typical-workflow-web-user.md
+++ b/docs/getting-started/typical-workflow-web-user.md
@@ -177,16 +177,14 @@ Install requirements + project
 
 ```yaml
 cd grid-tutorials/getting-started
-
 pip install -r requirements.txt
-pip install -e .
 ```
 
 now run the following command to train a resnet50 on 2 GPUs
 
 ```bash
 python flash-image-classifier.py \
-      --data_dir /datastores/cifar5
+      --data_dir /datastores/cifar5 \
       --gpus 2 \
       --epochs 4
 ```


### PR DESCRIPTION
This step is not required 
`pip install -e .`. The link below does not contain `setup.py` instructions.
https://github.com/Lightning-AI/grid-tutorials/tree/main/getting-started

