### PR TITLE
typo fix + multigpu note

### DIFF
--- a/docs/getting-started/typical-workflow-cli-user.md
+++ b/docs/getting-started/typical-workflow-cli-user.md
@@ -389,7 +389,7 @@ Now kick off the run with grid run
 
 :::note
 To convert the below run into a multi-gpu Run please set the `--instance_type` parameter to a machine with multiple gpus
-and update the `--gpus` argument to the desired number of GPUs. See [here](../platform/4_machines.md) for a list of machine types and their hardware specs.
+and update the `--gpus` argument to the desired number of GPUs. See [here](../platform/4_machines.md) for a table of machine types and their hardware specs.
 :::
 
 ```bash


### PR DESCRIPTION
# What does this PR do?

This PR fixes a typo and adds a note so users know how to convert from a single gpu run to a multi-gpu run.
